### PR TITLE
Adiciona DEBUG de aplicações feitas com Streamlit

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python:Streamlit",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "streamlit",
+            "args": [
+                "run",
+                "${file}",
+                "--server.port",
+                "2000"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
# Descrição

Configura o VSCode para debug de aplicativos feitos com [Streamlit](https://docs.streamlit.io/).

<img src="https://erickrribeiro.github.io/images/debugger-running.gif">

Para mais detalhes, consultar o post: [Como debugar aplicativos feitos com Streamlit no VSCode](https://erickrribeiro.github.io/vscode/depurando-aplicativo-streamlit-no-vscode)