### PR TITLE
Setting PYTHONPATH for local Jupyter Notebook in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
         "--config",
         "setup.cfg"
     ],
+    "jupyter.notebookFileRoot": "${workspaceFolder}",
     "python.defaultInterpreterPath": "${workspaceRoot}/.venv/bin/python3",
     "python.envFile": "${workspaceFolder}/.env",
     "python.terminal.activateEnvironment": true,


### PR DESCRIPTION
## Cenário


Considerando um projeto com a seguinte estrutura:
```
my-project
|--- utils
|------ pre_processing.py
|--- notebooks
|------ my_script.ipynb
|--- config.py
```

A seguinte mensagem de erro ocorre quando o arquivo `config.py` é importado dentro `notebooks/my_script.ipynb`:

> ModuleNotFoundError: No module named 'config'

## Correção

https://stackoverflow.com/questions/58735256/set-pythonpath-for-local-jupyter-notebook-in-vs-code